### PR TITLE
Added a job to change the dynamic settings of ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ An example of an operation file that will create 2 different index templates (`c
 - type: replace
   path: /instance_groups/name=elasticsearch-master/jobs/-
   value:
+    consumes:
+      elasticsearch:
+        from: elasticsearch-master
     name: elasticsearch-index-templates
     release: elasticsearch
     lifecycle: errand
@@ -62,4 +65,27 @@ An example of an operation file that will create 2 different index templates (`c
     } 
   } 
 }' }]
+```
+
+## Change dynamic properties
+
+If you want to change the cluster dynamic properties, you can do it with the `elasticsearch-dynamic-properties` errand job.
+This job will post a request to the `/_cluster/settings` ( [see more information about this here](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html) ) and the body can be defined in the properties.
+
+Here's an example of a valid operation file:
+```
+- type: replace
+  path: /instance_groups/name=elasticsearch-master/jobs/-
+  value:
+    name: elasticsearch-dynamic-properties
+    release: elasticsearch
+    lifecycle: errand
+    properties:
+      elasticsearch:
+        dynamic:
+          properties: '{
+            "persistent" : {
+        "indices.recovery.max_bytes_per_sec" : "72mb"
+    }
+}'
 ```

--- a/jobs/elasticsearch-dynamic-properties/spec
+++ b/jobs/elasticsearch-dynamic-properties/spec
@@ -1,0 +1,22 @@
+---
+name: elasticsearch-dynamic-properties
+
+templates:
+  bin/run.sh: bin/run
+
+properties: 
+  elasticsearch.protocol:
+    description: "Protocl of elasticsearch master to send elasticsearch requests to (http or https)"
+    default: "http"
+  elasticsearch.prefer_bosh_link:
+    description: "Use bosh link to connect elasticsearch in prioriy to kibana.elasticsearch.host/port"
+    default: true
+  elasticsearch.host:
+    description: "IP address of elasticsearch master to send elasticsearch requests to"
+    default: "127.0.0.1"
+  elasticsearch.port:
+    description: "Port of elasticsearch master to send elasticsearch requests to"
+    default: "9200"
+  elasticsearch.dynamic.properties:
+    description: "This is the body of the API PUT request. It should be a valid JSON file. In case you want to see a valid example, check the readme file."
+    default: ""

--- a/jobs/elasticsearch-dynamic-properties/templates/bin/run.sh
+++ b/jobs/elasticsearch-dynamic-properties/templates/bin/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+<%
+  elasticsearch_host = p("elasticsearch.host")
+  if p("elasticsearch.prefer_bosh_link") then
+      if_link("elasticsearch") { |elasticsearch_link| elasticsearch_host = elasticsearch_link.instances[0].address }
+  end
+
+  elasticsearch_url = p("elasticsearch.protocol") + '://' + elasticsearch_host + ':' + p("elasticsearch.port")
+%>
+
+# If a command fails, exit immediately
+set -e
+
+curl -k -X PUT "<%= elasticsearch_url %>/_cluster/settings" -H 'Content-Type: application/json' --data-binary '<%=p('elasticsearch.dynamic.properties') %>'


### PR DESCRIPTION
With this job it is now possible to change ES properties and save those
changes along with your bosh deployment. This means that you can store
your settings changes and have an immutable deployment.

This errand job will make a call to the `_cluster/settings` API with the
settings that we want to change.

README was updated to include an example.