### PR TITLE
Make xpack.monitoring configurable

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -72,3 +72,27 @@ properties:
       The strategy to enable allocation for specific kinds of shards (all / primaries / new_primaries) 
       see also https://www.elastic.co/guide/en/elasticsearch/reference/current/shards-allocation.html
     default: all
+  xpack.monitoring.enabled:
+    description: Set to `true` (default) to enable Elasticsearch X-Pack monitoring for Elasticsearch on the node.
+  xpack.monitoring.collection.enabled:
+    description: Set to `true` to enable the collection of monitoring data. When this setting is `false` (default), Elasticsearch monitoring data is not collected and all monitoring data from other sources such as Kibana, Beats, and Logstash is ignored.
+  xpack.monitoring.collection.interval:
+    description: Controls how often data samples are collected. Defaults to `10s`. If you modify the collection interval, set the `xpack.monitoring.min_interval_seconds` option in `kibana.yml` to the same value.
+  xpack.monitoring.elasticsearch.collection.enabled:
+    description: Controls whether statistics about your Elasticsearch cluster should be collected. Defaults to `true`. This is different from xpack.monitoring.collection.enabled, which allows you to enable or disable all monitoring collection. However, this setting simply disables the collection of Elasticsearch data while still allowing other data (e.g., Kibana, Logstash, Beats, or APM Server monitoring data) to pass through this cluster.
+  xpack.monitoring.collection.cluster.stats.timeout:
+    description: Sets the timeout for collecting the cluster statistics. Defaults to `10s`.
+  xpack.monitoring.collection.indices:
+    description: Controls which indices Monitoring collects data from. Defaults to all indices. Specify the index names as a comma-separated list, for example `test1,test2,test3`. Names can include wildcards, for example `test*`. You can explicitly include or exclude indices by prepending `+` to include the index, or `-` to exclude the index. For example, to include all indices that start with `test` except `test3`, you could specify `+test*,-test3`.
+  xpack.monitoring.collection.index.stats.timeout:
+    description: Sets the timeout for collecting index statistics. Defaults to `10s`.
+  xpack.monitoring.collection.index.recovery.active_only:
+    description: Controls whether or not all recoveries are collected. Set to `true` to collect only active recoveries. Defaults to `false`.
+  xpack.monitoring.collection.index.recovery.timeout:
+    description: Sets the timeout for collecting the recovery information. Defaults to `10s`.
+  xpack.monitoring.history.duration:
+    description: |
+      Sets the retention duration beyond which the indices created by a Monitoring exporter are automatically deleted. Defaults to `7d` (7 days).
+      This setting has a minimum value of `1d` (1 day) to ensure that something is being monitored, and it cannot be disabled.
+  xpack.monitoring.exporters:
+    description: Configures where the agent stores monitoring data. By default, the agent uses a local exporter that indexes monitoring data on the cluster where it is installed. Use an HTTP exporter to send data to a separate monitoring cluster.

--- a/jobs/elasticsearch/templates/config/elasticsearch.yml
+++ b/jobs/elasticsearch/templates/config/elasticsearch.yml
@@ -130,3 +130,44 @@ discovery.zen.minimum_master_nodes: <%= minimum_master_nodes %>
   end
 %>
 discovery.zen.ping.unicast.hosts: <%= master_hosts %>
+
+<% if_p('xpack.monitoring.enabled') do |enabled| -%>
+xpack.monitoring.enabled: <%= enabled %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.enabled') do |enabled| -%>
+xpack.monitoring.collection.enabled: <%= enabled %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.interval') do |interval| -%>
+xpack.monitoring.collection.interval: <%= interval %>
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.collection.enabled') do |enabled| -%>
+xpack.monitoring.elasticsearch.collection.enabled: <%= enabled %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.cluster.stats.timeout') do |timeout| -%>
+xpack.monitoring.collection.cluster.stats.timeout: <%= timeout %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.indices') do |indices| -%>
+xpack.monitoring.collection.indices: <%= indices %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.index.stats.timeout') do |timeout| -%>
+xpack.monitoring.collection.index.stats.timeout: <%= timeout %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.index.recovery.active_only') do |active_only| -%>
+xpack.monitoring.collection.index.recovery.active_only: <%= active_only %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.index.recovery.timeout') do |timeout| -%>
+xpack.monitoring.collection.index.recovery.timeout: <%= timeout %>
+<% end -%>
+<% if_p('xpack.monitoring.history.duration') do |duration| -%>
+xpack.monitoring.history.duration: <%= duration %>
+<% end -%>
+<%
+  if_p('xpack.monitoring.exporters') do |exporter|
+    exporter.each_key do |key|
+-%>
+xpack.monitoring.exporters:
+  <%= key %>: 
+    type: <%= exporter[key]["type"] %>
+    use_ingest: <%= exporter[key]["use_ingest"] %>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
X-Pack Monitoring settings in Elasticsearch on v6.6. X-Pack Monitoring can be used with no subscription. Plugins are installed by default.
https://www.elastic.co/guide/en/elasticsearch/reference/6.6/monitoring-settings.html

I also created ops-file for enabling monitorign in `elastic-stack-bosh-deployment`.