### PR TITLE
Added bosh zones to ES attributes

### DIFF
--- a/jobs/elasticsearch/templates/config/elasticsearch.yml
+++ b/jobs/elasticsearch/templates/config/elasticsearch.yml
@@ -92,6 +92,7 @@ network.host: 0.0.0.0
 path.logs: /var/vcap/sys/log/elasticsearch
 path.data: /var/vcap/store/elasticsearch
 node.name: <%= name %>/<%= index %>
+node.attr.zone: <%= spec.az %>
 node.master: <%= p("elasticsearch.node.allow_master") %>
 node.data: <%= p("elasticsearch.node.allow_data") %>
 node.ingest: <%= p("elasticsearch.node.allow_ingest") %>

--- a/spec/jobs/elasticsearch_spec.rb
+++ b/spec/jobs/elasticsearch_spec.rb
@@ -26,7 +26,7 @@ describe 'elasticsearch job' do
       expect(config['node.master']).to eq(true)
       expect(config['node.data']).to eq(true)
       expect(config['node.ingest']).to eq(false)
-			expect(config['node.attr.zone']).to eq('az1')
+      expect(config['node.attr.zone']).to eq('az1')
       expect(config['cluster.name']).to eq('test')
       expect(config['discovery.zen.minimum_master_nodes']).to eq(1)
       expect(config['discovery.zen.ping.unicast.hosts']).to eq('10.0.8.2')

--- a/spec/jobs/elasticsearch_spec.rb
+++ b/spec/jobs/elasticsearch_spec.rb
@@ -26,6 +26,7 @@ describe 'elasticsearch job' do
       expect(config['node.master']).to eq(true)
       expect(config['node.data']).to eq(true)
       expect(config['node.ingest']).to eq(false)
+			expect(config['node.attr.zone']).to eq('az1')
       expect(config['cluster.name']).to eq('test')
       expect(config['discovery.zen.minimum_master_nodes']).to eq(1)
       expect(config['discovery.zen.ping.unicast.hosts']).to eq('10.0.8.2')


### PR DESCRIPTION
As we can see in the oficial docs
(https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html),
ES can be smart enough to allocate primaries and replicas into different
zones. This is good because there may be outages in different zones,
when deploying the cluster in the cloud.

For this to work, we need to add the bosh zone to the ES attributes.
With this change, we are adding a new attribute to ES (named `zone`),
where the value is the bosh zone where the instance is being deployed
into.

This change alone won't do anything to allocation awareness, so people
that don't want to use it will still have the same behaviour as they had
before.

People that do want to use it need to change the
`cluster.routing.allocation.awareness.attributes` setting on the ES
cluster and add `zone` as a value there.
After this, ES will allocate shards taking into consideration the
allocation awareness mentioned in the link above.