### PR TITLE
Fixed some issues regarding plugins and keystore

### DIFF
--- a/jobs/elasticsearch/templates/bin/keystore-add.sh
+++ b/jobs/elasticsearch/templates/bin/keystore-add.sh
@@ -9,7 +9,7 @@ echo "<%= setting['command'] %>: <%= setting['name'] %>"
 <% if setting['command'] == 'add' then %>
 echo "<%= setting['value'] %>" | elasticsearch-keystore add -xf  <%= setting['name'] %>
 <% elsif setting['command'] == 'add-file'  %>
-elasticsearch-keystore add-file <%= setting['name'] %> <%= setting['value'] %>
+elasticsearch-keystore add-file --f <%= setting['name'] %> <%= setting['value'] %>
 <% elsif setting['command'] == 'remove'  %>
 elasticsearch-keystore remove <%= setting['name'] %> || true
 <% end %>

--- a/jobs/elasticsearch/templates/bin/pre-start
+++ b/jobs/elasticsearch/templates/bin/pre-start
@@ -7,7 +7,7 @@ mkdir -p /var/vcap/packages/elasticsearch/plugins
 # install plugins
 rm -rf /var/vcap/packages/elasticsearch/plugins/*
 <%
-  opts = p("elasticsearch.plugin_install_opts").join(' ')
+  opts = p("elasticsearch.plugin_install_opts")
 %>
 if [ -d /var/vcap/packages/elasticsearch-plugins ];then 
 	for f in `ls /var/vcap/packages/elasticsearch-plugins`;do 


### PR DESCRIPTION
The plugin options property is already a string, so the `.join()` method
does not work. Removed it and added a new test case for this issue.

The `--f` flag on the `keystore add-file` is necessary because ES will
ask if we want to create/override the existing key-store. Since this
command will be executed in every deployment, we need to force it so
that ES is not expecting an input from the user.