### PR TITLE
Updated property description

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -63,7 +63,8 @@ properties:
     description: "Plugins to run elasticsearch with (array[] = { plugin-name: install-source }; e.g. [ { analysis-kuromoji: 'analysis-kuromoji' } ])"
     default: []
   elasticsearch.plugin_install_opts:
-    description: "Command line parameters for 'elasticsearch-plugin install'" (should be an array of options; e.g. ['--batch'])
+    description: "Command line parameters for 'elasticsearch-plugin install'"
+    example: ['--batch']
     default: []
   elasticsearch.health.disable_post_start:
     description: Allow node to run post-start script? (true / false)

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -63,7 +63,7 @@ properties:
     description: "Plugins to run elasticsearch with (array[] = { plugin-name: install-source }; e.g. [ { analysis-kuromoji: 'analysis-kuromoji' } ])"
     default: []
   elasticsearch.plugin_install_opts:
-    description: "Command line parameters for 'elasticsearch-plugin install'"
+    description: "Command line parameters for 'elasticsearch-plugin install'" (should be an array of options; e.g. ['--batch'])
     default: []
   elasticsearch.health.disable_post_start:
     description: Allow node to run post-start script? (true / false)


### PR DESCRIPTION
Making it explicit that `elasticsearch.plugin_install_opts` is an array and should be defined as an array.