### PR TITLE
Fix start script and improve monit script

### DIFF
--- a/jobs/elasticsearch/monit
+++ b/jobs/elasticsearch/monit
@@ -1,5 +1,11 @@
 check process elasticsearch
   with pidfile /var/vcap/sys/run/elasticsearch/elasticsearch.pid
-  start program "/var/vcap/jobs/elasticsearch/bin/ctl start"
+  start program "/var/vcap/jobs/elasticsearch/bin/ctl start" 
   stop program "/var/vcap/jobs/elasticsearch/bin/ctl stop"
+  if failed host 127.0.0.1 port 9200
+    send "GET /_cluster/health HTTP/1.1\r\nUser-Agent: monit-health-check\r\nHost: localhost\r\nConnection: close\r\n\r\n\"
+    expect "HTTP/[0-9\.]{3} 200 OK\r\n"
+    timeout 30 seconds
+    for 10 cycles then stop
+
   group vcap

--- a/jobs/elasticsearch/templates/bin/ctl
+++ b/jobs/elasticsearch/templates/bin/ctl
@@ -38,11 +38,13 @@ case $1 in
     ulimit -u 4096
     sysctl -q -w vm.max_map_count=262144
 
+    (
     exec chpst -u $RUNAS:$RUNAS \
        /var/vcap/packages/elasticsearch/bin/elasticsearch \
-      -p $PIDFILE \
       <%= p("elasticsearch.exec.options", []).join(' ') %> \
       >>$LOG_DIR/elasticsearch.stdout.log 2>>$LOG_DIR/elasticsearch.stderr.log
+    ) &
+    echo $! > $PIDFILE
     ;;
 
   stop)


### PR DESCRIPTION
Due to a known bug with bosh (see issue for more information https://github.com/bosh-elastic-stack/elasticsearch-boshrelease/issues/25 ), we need to change the start script to start Elasticsearch process in a subshell.

But with this change we also need to change the monit script in order to
call ES healthcheck, because that's now the proper way for monit to report ES as running.

As far as we know, regarding monit, each cycle has a duration of 45
seconds. By looping for 10 cycles, we give to ES a maximum of 450seconds
until the process is successfully running. If the healthcheck doesn't
return a 200 within those 10 cycles (450 sec), then monit will stop the
process and report it as failing.